### PR TITLE
[8.1] Deprecated libraries removal from Android.mk

### DIFF
--- a/hal/Android.mk
+++ b/hal/Android.mk
@@ -12,9 +12,7 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/inc
 LOCAL_MODULE := liboffloadhal
 
 #LOCAL_CPP_FLAGS := -Wall -Werror
-LOCAL_SHARED_LIBRARIES := libhwbinder \
-                        libhidlbase \
-                        libhidltransport \
+LOCAL_SHARED_LIBRARIES := libhidlbase \
                         liblog \
                         libcutils \
                         libdl \

--- a/ipacm/src/Android.mk
+++ b/ipacm/src/Android.mk
@@ -108,9 +108,7 @@ LOCAL_SHARED_LIBRARIES += libipanat
 LOCAL_SHARED_LIBRARIES += libxml2
 LOCAL_SHARED_LIBRARIES += libnfnetlink
 LOCAL_SHARED_LIBRARIES += libnetfilter_conntrack
-LOCAL_SHARED_LIBRARIES += libhwbinder \
-                libhidlbase \
-                libhidltransport \
+LOCAL_SHARED_LIBRARIES += libhidlbase \
                 liblog \
                 libcutils \
                 libdl \


### PR DESCRIPTION
This was done because Q deprecated those libraries and they are no longer needed
and thus should be removed.
Symbols provided by those libraries are now part of libhidlbase.