### PR TITLE
[9.14] Don't set verbose compiler flag

### DIFF
--- a/hal/Android.bp
+++ b/hal/Android.bp
@@ -10,9 +10,9 @@ cc_library_shared {
     ],
 
     shared_libs: [
-        "libhwbinder",
+
         "libhidlbase",
-        "libhidltransport",
+
         "liblog",
         "libcutils",
         "libdl",

--- a/ipacm/Android.bp
+++ b/ipacm/Android.bp
@@ -4,7 +4,7 @@ cc_binary {
     local_include_dirs: ["src"] + ["inc"],
     header_libs: ["qti_kernel_headers"],
 
-    cflags: ["-v"] + ["-DFEATURE_IPA_ANDROID"] + ["-DFEATURE_IPACM_RESTART"] + [
+    cflags: ["-DFEATURE_IPA_ANDROID"] + ["-DFEATURE_IPACM_RESTART"] + [
         "-DFEATURE_IPACM_HAL",
         "-DDEBUG",
         "-Wall",

--- a/ipacm/Android.bp
+++ b/ipacm/Android.bp
@@ -1,13 +1,12 @@
-
 cc_binary {
     name: "ipacm",
 
     local_include_dirs: ["src"] + ["inc"],
-	header_libs: ["qti_kernel_headers"],
+    header_libs: ["qti_kernel_headers"],
 
     cflags: ["-v"] + ["-DFEATURE_IPA_ANDROID"] + ["-DFEATURE_IPACM_RESTART"] + [
         "-DFEATURE_IPACM_HAL",
-	"-DDEBUG",
+        "-DDEBUG",
         "-Wall",
         "-Werror",
         "-Wno-error=macro-redefined",
@@ -41,11 +40,11 @@ cc_binary {
     vendor: true,
 
     shared_libs: [
-	"liboffloadhal",
-	"libipanat",
-	"libxml2",
-	"libnfnetlink",
-	"libnetfilter_conntrack",
+        "liboffloadhal",
+        "libipanat",
+        "libxml2",
+        "libnfnetlink",
+        "libnetfilter_conntrack",
         "libhidlbase",
         "liblog",
         "libcutils",

--- a/ipanat/Android.bp
+++ b/ipanat/Android.bp
@@ -10,8 +10,8 @@ cc_library_shared {
         "src/ipa_nat_drvi.c",
     ],
 
-   shared_libs:
-        ["libcutils",
+    shared_libs: [
+        "libcutils",
         "libdl",
         "libbase",
         "libutils",


### PR DESCRIPTION
- Run `bpfix -w -l **/*.bp` to de-garbage-ify BluePrint files
- ipacm: Remove unnecessary verbose option from cflags
