### PR TITLE
[9.14] Android U support

### DIFF
--- a/ipacm/Android.bp
+++ b/ipacm/Android.bp
@@ -36,7 +36,6 @@ cc_binary {
         "src/IPACM_LanToLan.cpp",
     ],
 
-    clang: true,
     vendor: true,
 
     shared_libs: [
@@ -66,5 +65,4 @@ prebuilt_etc {
     vendor: true,
     owner: "ipacm",
     src: "src/IPACM_cfg.xml",
-
 }

--- a/ipacm/inc/IPACM_Netlink.h
+++ b/ipacm/inc/IPACM_Netlink.h
@@ -51,9 +51,6 @@ extern "C"
 #include <pthread.h>
 #include <sys/select.h>
 #include <sys/socket.h>
-#include <linux/socket.h>
-#include <inaddr.h>
-#define sockaddr_storage __kernel_sockaddr_storage
 #include <linux/if.h>
 #include <linux/if_addr.h>
 #include <linux/rtnetlink.h>

--- a/ipanat/Android.bp
+++ b/ipanat/Android.bp
@@ -1,5 +1,3 @@
-
-
 cc_library_shared {
     name: "libipanat",
 
@@ -23,6 +21,4 @@ cc_library_shared {
         "-Wall",
         "-Werror",
     ] + ["-DFEATURE_IPA_ANDROID"],
-
-    clang: true,
 }


### PR DESCRIPTION
### [Drop deprecated `clang: true` property from `Android.bp`](https://github.com/sonyxperiadev/vendor-qcom-opensource-data-ipa-cfg-mgr/pull/3/commits/c2e5b416549e8d31d7a10b55c3d283e090d6d1bd)

All C(++) code in Android now builds with `clang`, setting this property no longer has effect nor meaning.

https://android.googlesource.com/platform/build/+/master/Changes.md#stop-using-clang-property

### [Revert "Kernel Header Changes"](https://github.com/sonyxperiadev/vendor-qcom-opensource-data-ipa-cfg-mgr/pull/3/commits/c0d5ce0f2b85a8d65bc43b59587448e2dc966861)

Defining `sockaddr_storage` no longer should be necessary since Android T (and Android U, where `inaddr.h` is now completely gone!) define it directly in `bionic` in `sys/socket.h`:
https://cs.android.com/android/_/android/platform/bionic/+/d27506716af69ede1334cbd5163186c10ab56a0f

This reverts commit 51c7674d8f90209d5238249145ad5f093dddc9fc.