### PR TITLE
[ 2.0.r1] Define IPA_HW_v5_5 for older kernels

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,0 +1,2 @@
+soong_namespace {
+}

--- a/ipacm/Android.bp
+++ b/ipacm/Android.bp
@@ -39,7 +39,6 @@ cc_binary {
     ],
 
     init_rc: ["src/ipacm.rc"],
-    clang: true,
     vendor: true,
 
     shared_libs: [

--- a/ipacm/src/IPACM_ConntrackListener.cpp
+++ b/ipacm/src/IPACM_ConntrackListener.cpp
@@ -71,6 +71,10 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
 #include "IPACM_Wan.h"
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
+#ifndef IPA_HW_v5_5
+#define IPA_HW_v5_5  24
+#endif
+
 IPACM_ConntrackListener::IPACM_ConntrackListener()
 {
 	 IPACMDBG("\n");

--- a/ipanat/Android.bp
+++ b/ipanat/Android.bp
@@ -22,7 +22,6 @@ cc_library_shared {
     ],
     export_include_dirs: ["inc"],
     vendor: true,
-    clang: true,
 
     cflags: ["-DDEBUG"] + ["-DFEATURE_IPA_ANDROID"] + ["-Wno-int-conversion"],
 


### PR DESCRIPTION
Define IPA_HW_v5_5 to enable compilation with kernel
headers prior to version 5.15. IPAv5.5 was introduced in
kernel 5.15, and to compile the library with earlier kernel
headers, this define should be added as a workaround.