### PR TITLE
[9.16.r1] Android.bp: Define IPACM soong namespace

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,0 +1,2 @@
+soong_namespace {
+}

--- a/ipacm/Android.bp
+++ b/ipacm/Android.bp
@@ -37,6 +37,7 @@ cc_binary {
         "src/IPACM_LanToLan.cpp",
     ],
 
+    init_rc: ["src/ipacm.rc"],
     vendor: true,
 
     shared_libs: [


### PR DESCRIPTION
We will probably have two IPACM repos (upstream and legacy
for k4.19 targets) at the same time and each of them has
blueprints with modules with the same names, so we need to
separate their namespaces. The namespace of the needed one
for a certain kernel version is included using
PRODUCT_SOONG_NAMESPACES.